### PR TITLE
feat/added exact match option

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,11 @@ Performs a fuzzy search on the provided nested data.
 
 `options`:
 
-- `options` can have three values:
+- `options` can have four values:
   - **`threshold`**: The minimum similarity score (default: `0.6`)
   - **`outputMode`**: The type of output you want (default: `flat`)
   - **`excludeKeys`**: The array of keys you want to exclude (default: `[]`)
+  - **`exact`**: Its a boolean value if its true, it will strict check the query instead of similarity score (default: `false`)
 
 #### Returns:
 

--- a/types/nested-fuzzy-search.d.ts
+++ b/types/nested-fuzzy-search.d.ts
@@ -13,6 +13,7 @@ declare module "nested-fuzzy-search" {
       threshold?: number;
       outputMode?: "flat" | "tree";
       excludeKeys?: string[];
+      exact?: boolean;
     }
   ): SearchResult[];
 }


### PR DESCRIPTION
This PR contains the `exact` option, it will strict check the query instead of similarity score (default: `false`)